### PR TITLE
feat: Added option to skip stripping elf

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ title_name = "My application"
 assets = "static"
 # Optional, this is the default
 build_std = "std,panic_unwind"
-# Optional, true by default. Will strip debug symbols from the resulting elf
+# Optional, true by default. Will strip debug symbols from the resulting elf when enabled.
 strip = true
 # Optional, this is the default
 vita_strip_flags = ["-g"]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ title_name = "My application"
 assets = "static"
 # Optional, this is the default
 build_std = "std,panic_unwind"
+# Optional, true by default. Will strip debug symbols from the resulting elf
+strip = true
 # Optional, this is the default
 vita_strip_flags = ["-g"]
 # Optional, this is the default

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -280,6 +280,11 @@ impl<'a> BuildContext<'a> {
     }
 
     fn strip(&self, art: &ExecutableArtifact) -> anyhow::Result<()> {
+        if !art.meta.strip {
+            info!("{}", "Skipping elf strip".yellow());
+            return Ok(());
+        }
+
         let mut command = Command::new(self.sdk_binary("arm-vita-eabi-strip"));
 
         command

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -58,6 +58,10 @@ impl FromStr for TitleId {
     }
 }
 
+fn default_strip() -> bool {
+    true
+}
+
 fn default_build_std() -> String {
     "std,panic_unwind".to_string()
 }
@@ -81,6 +85,8 @@ pub struct PackageMetadata {
     pub assets: Option<String>,
     #[serde(default = "default_build_std")]
     pub build_std: String,
+    #[serde(default = "default_strip")]
+    pub strip: bool,
     #[serde(default = "default_vita_strip_flags")]
     pub vita_strip_flags: Vec<String>,
     #[serde(default = "default_vita_make_fself_flags")]
@@ -96,6 +102,7 @@ impl Default for PackageMetadata {
             title_name: None,
             assets: None,
             build_std: default_build_std(),
+            strip: default_strip(),
             vita_strip_flags: default_vita_strip_flags(),
             vita_make_fself_flags: default_vita_make_fself_flags(),
             vita_mksfoex_flags: default_vita_mksfoex_flags(),


### PR DESCRIPTION
Even though in most cases stripping should be enabled since a hello world binary with std with debug symbols yields a ~13mb elf for Vita, debugging isolated problems could benefit from dwarf symbols.

This PR adds a flag readable from `Cargo.toml` which can toggle stripping on and off (with on by default)