### PR TITLE
feat: Use vitasdk's pkg-config wrapper so that VITASDK variable gets set

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -234,7 +234,6 @@ impl BuildContext<'_> {
                     self.sdk("arm-vita-eabi").join("include")
                 })
                 .pass_path_env("PKG_CONFIG", || self.sdk_binary("arm-vita-eabi-pkg-config"))
-                .pass_env("PKG_CONFIG_SYSROOT_DIR", || &self.sdk)
                 .env("VITASDK", &self.sdk)
                 .arg("build")
                 .arg("-Z")

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -233,9 +233,7 @@ impl<'a> BuildContext<'a> {
                 .pass_path_env("OPENSSL_INCLUDE_DIR", || {
                     self.sdk("arm-vita-eabi").join("include")
                 })
-                .pass_path_env("PKG_CONFIG_PATH", || {
-                    self.sdk("arm-vita-eabi").join("lib").join("pkgconfig")
-                })
+                .pass_path_env("PKG_CONFIG", || self.sdk_binary("arm-vita-eabi-pkg-config"))
                 .pass_env("PKG_CONFIG_SYSROOT_DIR", || &self.sdk)
                 .env("VITASDK", &self.sdk)
                 .arg("build")

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -205,7 +205,7 @@ impl Executor for Build {
     }
 }
 
-impl<'a> BuildContext<'a> {
+impl BuildContext<'_> {
     fn build_elf(&self) -> anyhow::Result<Vec<ExecutableArtifact>> {
         let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
 


### PR DESCRIPTION
`arm-vita-eabi-pkg-config` sets the VITASDK variable to the `VITASDK` env as `.pc` files cannot access the environment. This is required by `arm-vita-eabi/lib/pkgconfig/SDL2_ttf.pc` and probably others.

See also https://github.com/rust-lang/pkg-config-rs/blob/3314c8de34cbd459caf8c8a5ae4e94efa9037e3a/src/lib.rs#L290-L293